### PR TITLE
Added QString fileList

### DIFF
--- a/ComAudio/ComAudio.cpp
+++ b/ComAudio/ComAudio.cpp
@@ -61,6 +61,8 @@ int ComAudio::initUi()
 	// slider: volume
 	connect(ui->horizontalSlider_player_volume, &QSlider::sliderMoved, this, &ComAudio::setVolume);
 
+	fileListString = getFileList();
+
 	return 0;
 }
 
@@ -170,4 +172,21 @@ void ComAudio::metaDataChanged()
 			ui->label_player_artist->setPixmap(!url.isEmpty() ? QPixmap(url.toString()) : QPixmap());
 		}
 	}
+}
+
+QString ComAudio::getFileList()
+{
+	//QString fileName = fileModel->fileName(QModelIndex index())
+	QDir a(pathLocal);
+	QStringList filters;
+	QStringList fileList;
+
+	filters << "*.wav";
+
+	a.setNameFilters(filters);
+	a.setFilter(QDir::Files);
+
+	fileList = a.entryList();
+	
+	return fileList.join('\n') + '\r';
 }

--- a/ComAudio/ComAudio.h
+++ b/ComAudio/ComAudio.h
@@ -29,6 +29,7 @@ public:
 	void selectFile();
 	void playAudio();
 	void setVolume();
+	QString getFileList();
 
 	void metaDataChanged();
 
@@ -47,6 +48,7 @@ private:
 	// file browser
 	QFileSystemModel *dirModel;
 	QFileSystemModel *fileModel;
+	QString fileListString;
 	QString pathLocal;
 	QString pathFile;
 	// audio player


### PR DESCRIPTION
Added ComAudio::getFileList function to retrieve a QString containing all the .wav files in the directory (delineated by '\n', ending in '\r')